### PR TITLE
Add type annotations, add docstrings, replace `os` path strings by `pathlib`'s `Path` objects relative to globally configurable folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ vocab_builder = SaGeVocabBuilder(full_vocab_schedule=[262144, 229376, 196608, 16
                                  embeddings_schedule=[262144, 131072, 65536, 49152, 40960, 32768],
                                  workers_number=4)
 
-vocab_builder.build_vocab(experiment_name='experiment_name', 
-                          corpus_filepath='data/wiki_lines.txt', 
-                          vocabulary_filepath='data/initial_vocab_hex.vocab')                     
+vocab_builder.build_vocab(experiment_name='experiment_name',
+                          initial_vocabulary='data/initial_vocab_hex.vocab',
+                          corpus='data/wiki_lines.txt')
 ```
 SaGe tokenizer can be installed from PyPI:
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "sage-tokenizer"
 version = "2.0.0"
 dependencies = [
     "gensim == 4.3.2",
-    "scipy == 1.12.0"
+    "scipy == 1.12.0",
+    "datasets"
 ]
 authors = [
     { name="Shaked Yehezkel"},

--- a/src/main.py
+++ b/src/main.py
@@ -49,23 +49,24 @@ def load_args():
 if __name__ == '__main__':
     args = load_args()
     vocab_builder = SaGeVocabBuilder(
-        args['vocabulary_schedule'],
-        args['embeddings_schedule'],
-        args['max_len'],
-        args['workers'],
-        args['random_seed'],
-        args['word2vec_D'],
-        args['word2vec_N'],
-        args['word2vec_ALPHA'],
-        args['word2vec_window_size'],
-        args['word2vec_min_count'],
-        args['word2vec_sg']
+        full_vocab_schedule=args['vocabulary_schedule'],
+        embeddings_schedule=args['embeddings_schedule'],
+        max_len=args['max_len'],
+        workers_number=args['workers'],
+        random_seed=args['random_seed'],
+        word2vec_d=args['word2vec_D'],
+        word2vec_n=args['word2vec_N'],
+        word2vec_alpha=args['word2vec_ALPHA'],
+        word2vec_window_size=args['word2vec_window_size'],
+        word2vec_min_count=args['word2vec_min_count'],
+        word2vec_sg=args['word2vec_sg']
     )
 
     vocab_builder.build_vocab(
-        args['experiment_name'],
-        args['corpus_filepath'],
-        args['initial_vocabulary_filepath'],
-        args['partial_corpus_filepath'],
-        args['partial_corpus_line_number'],
+        experiment_name=args['experiment_name'],
+        corpus=args['corpus_filepath'],
+        initial_vocabulary=args['initial_vocabulary_filepath'],
+        k_corpus_examples=args['partial_corpus_line_number'],
+
+        corpus_cache=args['partial_corpus_filepath'] if args['partial_corpus_filepath'] else "corpus"
     )

--- a/src/sage_tokenizer/SaGeVocabBuilder.py
+++ b/src/sage_tokenizer/SaGeVocabBuilder.py
@@ -156,35 +156,35 @@ class SaGeVocabBuilder:
             save_stats(stats, stats_folder, target_vocab_size)
 
             # these are the tokens to be removed
-            tokens_to_prune = set([sage_model.id_to_bytes(tid) for (loss, tid) in sorted_losses[:num_tokens_to_prune]])
+            tokens_to_prune = {sage_model.id_to_bytes(tid) for (loss, tid) in sorted_losses[:num_tokens_to_prune]}
             # double check there are no single bytes tokens to prune here
             single_byte_tokens_to_prune = [token for token in tokens_to_prune if len(token) == 1]
             assert len(single_byte_tokens_to_prune) == 0
 
             # our active vocabulary *after* pruning
             # is active if it has an entry in token_to_losses
-            active_vocab = {tok: tid for (tok, tid) in sage_model.get_vocabulary().items()
+            active_vocab = {tok: tid for tok, tid in sage_model.get_vocabulary().items()
                             if tid in token_to_losses and tok not in tokens_to_prune}
 
             # our overall vocabulary after pruning
-            target_vocab = {tok: tid for (tok, tid) in sage_model.get_vocabulary().items()
+            target_vocab = {tok: tid for tok, tid in sage_model.get_vocabulary().items()
                             if tok not in tokens_to_prune}
 
             # the deleted items
-            deleted_vocab = {tok: tid for (tok, tid) in sage_model.get_vocabulary().items()
+            deleted_vocab = {tok: tid for tok, tid in sage_model.get_vocabulary().items()
                              if tok in tokens_to_prune}
 
-            vocab_save_name = f"{vocab_folder}/sage_vocab_{target_vocab_size}.vocab"
-            logging.info(f"Saving intermediate vocab of size {len(target_vocab)} to {vocab_save_name}")
+            vocab_save_name = vocab_folder / f"sage_vocab_{target_vocab_size}.vocab"
+            logging.info(f"Saving intermediate vocab of size {len(target_vocab)} to {vocab_save_name.as_posix()}")
             write_vocab(target_vocab, vocab_save_name)
 
-            active_save_name = f"{vocab_folder}/active_vocab_{target_vocab_size}.vocab"
-            logging.info(f"Saving active vocab of size {len(active_vocab)} to {active_save_name}")
+            active_save_name = vocab_folder / f"active_vocab_{target_vocab_size}.vocab"
+            logging.info(f"Saving active vocab of size {len(active_vocab)} to {active_save_name.as_posix()}")
             write_vocab(active_vocab, active_save_name)
 
             # save the deleted ones too for analysis, with the original size
-            deleted_save_name = f"{vocab_folder}/deleted_vocab_{target_vocab_size}.vocab"
-            logging.info(f"Saving deleted vocab of size {len(deleted_vocab)} to {deleted_save_name}")
+            deleted_save_name = vocab_folder / f"deleted_vocab_{target_vocab_size}.vocab"
+            logging.info(f"Saving deleted vocab of size {len(deleted_vocab)} to {deleted_save_name.as_posix()}")
             write_vocab(deleted_vocab, deleted_save_name)
 
             # now update the internal state of sage_model to use the new smaller vocab

--- a/src/sage_tokenizer/__init__.py
+++ b/src/sage_tokenizer/__init__.py
@@ -1,0 +1,3 @@
+from .SaGeVocabBuilder import SaGeVocabBuilder
+from .model import SaGeTokenizer
+from .paths import setSageFolder

--- a/src/sage_tokenizer/embeddings.py
+++ b/src/sage_tokenizer/embeddings.py
@@ -22,6 +22,7 @@ from pathlib import Path
 #             yield self._model.tokenize_to_encoded_str(bytes(line, 'utf-8'))
 from .Word2VecParams import Word2VecParams
 from .model import SaGeTokenizer
+from .paths import getDataFolder
 
 
 def get_embeddings(vocab_size: int, embeddings_folder: Path, partial_corpus: List[str], sage_model: SaGeTokenizer, workers_number: int, word2vec_params: Word2VecParams):
@@ -49,7 +50,7 @@ def train_embeddings(sage_model: SaGeTokenizer, partial_corpus: List[str], worke
     # which gensim's word2vec wants to process things in parallel
     # see https://github.com/RaRe-Technologies/gensim/releases/tag/3.6.0
     # and https://github.com/RaRe-Technologies/gensim/blob/develop/docs/notebooks/Any2Vec_Filebased.ipynb
-    gensim_corpus_filepath = Path(".") / "data" / f"gensim_{sage_model.vocab_size()}.txt"
+    gensim_corpus_filepath = getDataFolder() / f"gensim_{sage_model.vocab_size()}.txt"
 
     # if already exists, use otherwise create the file
     if gensim_corpus_filepath.exists():

--- a/src/sage_tokenizer/embeddings.py
+++ b/src/sage_tokenizer/embeddings.py
@@ -43,7 +43,7 @@ def train_embeddings(sage_model: SaGeTokenizer, partial_corpus: Iterable[str], w
         for i,s in enumerate(partial_corpus):
             if i % 1_000_000 == 0:
                 logging.info(f"\tTokenizing example {i}, time: {(time.time() - start):.2f} seconds")
-            yield " ".join(sage_model.tokenize_to_encoded_str(bytes(s, 'utf-8')))  # GenSim expects a corpus consisting of whitespace-separated tokens.
+            yield " ".join(sage_model.tokenize_to_encoded_str(sage_model.pretokenize(s)))  # GenSim expects a corpus consisting of whitespace-separated tokens.
 
     if isinstance(partial_corpus, FileAsStringIterable):  # GenSim is accelerated for file-stored corpora (https://github.com/RaRe-Technologies/gensim/releases/tag/3.6.0 and https://github.com/RaRe-Technologies/gensim/blob/develop/docs/notebooks/Any2Vec_Filebased.ipynb).
         gensim_file = embeddings_folder / f"gensim_{sage_model.vocab_size()}.txt"

--- a/src/sage_tokenizer/embeddings.py
+++ b/src/sage_tokenizer/embeddings.py
@@ -1,12 +1,13 @@
 # Copyright © 2023 Kensho Technologies, LLC
 
-import os
 import time
 import logging
 
 import gensim.models
 import numpy as np
 
+from typing import List
+from pathlib import Path
 
 # class CorpusIterator:
 #     def __init__(self, model, corpus_filepath):
@@ -19,37 +20,40 @@ import numpy as np
 #         for line in corpus_data:
 #             # convert bytes to tokens in encoded string form, for gensim
 #             yield self._model.tokenize_to_encoded_str(bytes(line, 'utf-8'))
+from .Word2VecParams import Word2VecParams
+from .model import SaGeTokenizer
 
-def get_embeddings(vocab_size, embeddings_folder, partial_corpus, sage_model, workers_number, word2vec_params):
+
+def get_embeddings(vocab_size: int, embeddings_folder: Path, partial_corpus: List[str], sage_model: SaGeTokenizer, workers_number: int, word2vec_params: Word2VecParams):
     logging.info(f"training Embeddings at vocab size {vocab_size}")
     # is there an embedding of this size
-    embeddings_filepath = f"{embeddings_folder}/embeddings_{vocab_size}.npy"
-    if os.path.exists(embeddings_filepath):
-        logging.info(f"Found trained embeddings. Loading it from {embeddings_filepath}")
+    embeddings_filepath = Path(embeddings_folder) / f"embeddings_{vocab_size}.npy"
+    if embeddings_filepath.exists():
+        logging.info(f"Found trained embeddings. Loading it from {embeddings_filepath.as_posix()}")
         # context and target embeddings are the same so just keep one copy around
-        embeddings = np.load(embeddings_filepath)
+        embeddings = np.load(embeddings_filepath.as_posix())
     else:
         logging.info(f"Start training embeddings with Word2Vec...")
         start_time = time.time()
         embeddings = train_embeddings(sage_model, partial_corpus, workers_number, word2vec_params)
-        logging.info(f"Embeddings time:{time.time() - start_time}")
-        logging.info(f"Save embeddings to {embeddings_filepath}")
-        np.save(embeddings_filepath, embeddings, allow_pickle=True)
+        logging.info(f"Embeddings time: {time.time() - start_time}")
+        logging.info(f"Save embeddings to {embeddings_filepath.as_posix()}")
+        np.save(embeddings_filepath.as_posix(), embeddings, allow_pickle=True)
     return embeddings
 
 
-def train_embeddings(sage_model, partial_corpus, workers, word2vec_params):
+def train_embeddings(sage_model: SaGeTokenizer, partial_corpus: List[str], workers: int, word2vec_params: Word2VecParams):
     # sentences = CorpusIterator(model, corpus_filepath)
 
     # also save in a version of this with a sentence per line, whitespace per token
     # which gensim's word2vec wants to process things in parallel
     # see https://github.com/RaRe-Technologies/gensim/releases/tag/3.6.0
     # and https://github.com/RaRe-Technologies/gensim/blob/develop/docs/notebooks/Any2Vec_Filebased.ipynb
-    gensim_corpus_filepath = f"data/gensim_{sage_model.vocab_size()}.txt"
+    gensim_corpus_filepath = Path(".") / "data" / f"gensim_{sage_model.vocab_size()}.txt"
 
     # if already exists, use otherwise create the file
-    if os.path.exists(gensim_corpus_filepath):
-        logging.info(f"Gensim format data file already exists: {gensim_corpus_filepath}")
+    if gensim_corpus_filepath.exists():
+        logging.info(f"Gensim format data file already exists: {gensim_corpus_filepath.as_posix()}")
     else:
         gensim_start = time.time()
         logging.info(f"starting tokenization of {len(partial_corpus)} lines for gensim")
@@ -58,9 +62,9 @@ def train_embeddings(sage_model, partial_corpus, workers, word2vec_params):
                 if i % 1000000 == 0:
                     logging.info(f"tokenizing line {i}, time: {(time.time() - gensim_start):.2f}")
                 gensim_file.write(" ".join(sage_model.tokenize_to_encoded_str(bytes(line, 'utf-8'))) + "\n")
-        logging.info(f"Gensim format data written: {gensim_corpus_filepath}, time: {(time.time()-gensim_start):.2f}")
+        logging.info(f"Gensim format data written: {gensim_corpus_filepath.as_posix()}, time: {(time.time()-gensim_start):.2f}")
 
-    word2vec_model = gensim.models.Word2Vec(corpus_file=gensim_corpus_filepath,
+    word2vec_model = gensim.models.Word2Vec(corpus_file=gensim_corpus_filepath.as_posix(),
                                             vector_size=word2vec_params.D,
                                             negative=word2vec_params.N,
                                             alpha=word2vec_params.ALPHA,

--- a/src/sage_tokenizer/embeddings.py
+++ b/src/sage_tokenizer/embeddings.py
@@ -25,7 +25,7 @@ from .model import SaGeTokenizer
 from .paths import getDataFolder
 
 
-def get_embeddings(vocab_size: int, embeddings_folder: Path, partial_corpus: List[str], sage_model: SaGeTokenizer, workers_number: int, word2vec_params: Word2VecParams):
+def get_embeddings(vocab_size: int, embeddings_folder: Path, partial_corpus: List[str], sage_model: SaGeTokenizer, workers_number: int, word2vec_params: Word2VecParams) -> np.ndarray:
     logging.info(f"training Embeddings at vocab size {vocab_size}")
     # is there an embedding of this size
     embeddings_filepath = Path(embeddings_folder) / f"embeddings_{vocab_size}.npy"
@@ -43,7 +43,7 @@ def get_embeddings(vocab_size: int, embeddings_folder: Path, partial_corpus: Lis
     return embeddings
 
 
-def train_embeddings(sage_model: SaGeTokenizer, partial_corpus: List[str], workers: int, word2vec_params: Word2VecParams):
+def train_embeddings(sage_model: SaGeTokenizer, partial_corpus: List[str], workers: int, word2vec_params: Word2VecParams) -> np.ndarray:
     # sentences = CorpusIterator(model, corpus_filepath)
 
     # also save in a version of this with a sentence per line, whitespace per token
@@ -60,7 +60,7 @@ def train_embeddings(sage_model: SaGeTokenizer, partial_corpus: List[str], worke
         logging.info(f"starting tokenization of {len(partial_corpus)} lines for gensim")
         with open(gensim_corpus_filepath, "w", encoding="utf-8") as gensim_file:
             for i, line in enumerate(partial_corpus):
-                if i % 1000000 == 0:
+                if i % 1_000_000 == 0:
                     logging.info(f"tokenizing line {i}, time: {(time.time() - gensim_start):.2f}")
                 gensim_file.write(" ".join(sage_model.tokenize_to_encoded_str(bytes(line, 'utf-8'))) + "\n")
         logging.info(f"Gensim format data written: {gensim_corpus_filepath.as_posix()}, time: {(time.time()-gensim_start):.2f}")

--- a/src/sage_tokenizer/model.py
+++ b/src/sage_tokenizer/model.py
@@ -11,10 +11,10 @@ class SaGeTokenizer:
 
     def __init__(self, initial_vocabulary, max_len: int=16):
         self.hfe = HFEncoding()
-        self.byte_vocab: Dict[bytes, int] = None
+        self.byte_vocab: Dict[bytes, int]     = None
         self.inv_byte_vocab: Dict[int, bytes] = None
-        self.str_vocab: Dict[str, int] = None
-        self.inv_str_vocab: Dict[int, str] = None
+        self.str_vocab: Dict[str, int]        = None
+        self.inv_str_vocab: Dict[int, str]    = None
 
         self.set_vocabulary(initial_vocabulary)
         self.max_len = max_len

--- a/src/sage_tokenizer/model.py
+++ b/src/sage_tokenizer/model.py
@@ -78,17 +78,23 @@ class SaGeTokenizer:
             # add that with a "good" score
             vocab[tid] = score
 
-    def tokenize(self, sent: Tokenizable, tokens_only: bool=False) -> Union[List[int], List[Tuple[int, int, int]]]:
+    def pretokenize(self, sentence: Tokenizable) -> bytes:
+        try:  # Most frequent use-case is tokenising a string, so this is much faster than `if isinstance(sentence, str)`.
+            return sentence.encode("utf-8")
+        except:
+            return sentence
+
+    def tokenize(self, sentence: Tokenizable, tokens_only: bool=False) -> Union[List[int], List[Tuple[int, int, int]]]:
         """
         Split the gives sentence into tokens and convert them to IDs.
         """
-        if isinstance(sent, str):
-            sent = bytes(sent, encoding='utf-8')
+        sentence = self.pretokenize(sentence)
+
         data = []
         i = 0
-        while i < len(sent):  # Iterate through the sentence input
+        while i < len(sentence):  # Iterate through the sentence input
             for j in range(self.max_len, 0, -1):  # Find the longest possible token
-                tok = sent[i:i + j]
+                tok = sentence[i:i + j]
                 if tok in self.byte_vocab:
                     if tokens_only:
                         # Only add token_id to results

--- a/src/sage_tokenizer/paths.py
+++ b/src/sage_tokenizer/paths.py
@@ -1,0 +1,23 @@
+import os
+from pathlib import Path
+
+
+PATH_SAGE = Path(os.getcwd())
+def setSageFolder(path: Path):
+    global PATH_SAGE
+    PATH_SAGE = path
+
+def getDataFolder() -> Path:
+    path = PATH_SAGE / "data"
+    path.mkdir(exist_ok=True)
+    return path
+
+def getResultsFolder() -> Path:
+    path = PATH_SAGE / "results"
+    path.mkdir(exist_ok=True)
+    return path
+
+def getLogsFolder() -> Path:
+    path = PATH_SAGE / "logs"
+    path.mkdir(exist_ok=True)
+    return path

--- a/src/sage_tokenizer/utils.py
+++ b/src/sage_tokenizer/utils.py
@@ -15,6 +15,7 @@ from .model import SaGeTokenizer
 
 # only log code outside of multiprocessing
 # logger = logging.getLogger(__name__)
+from .paths import getDataFolder, getLogsFolder, getResultsFolder
 
 
 def write_vocab(vocab, filename):
@@ -40,7 +41,7 @@ def save_sorted_losses(sage_model: SaGeTokenizer, sorted_losses, target_vocab_si
     worst_500_filepath     = vocab_folder / f"worst_500_{target_vocab_size}.txt"
     best_500_filepath      = vocab_folder / f"best_500_{target_vocab_size}.txt"
 
-    logging.info(f"Saving sorted losses to {sorted_losses_filepath}")
+    logging.info(f"Saving sorted losses to {sorted_losses_filepath.as_posix()}")
     write_sorted_losses_into_file(sorted_losses,   sorted_losses_filepath, sage_model)
     write_sorted_losses_into_file(sorted_losses[:500], worst_500_filepath, sage_model)
     write_sorted_losses_into_file(sorted_losses[-500:], best_500_filepath, sage_model)
@@ -93,9 +94,7 @@ def load_corpus(corpus_filepath: Path, partial_corpus_filepath: Optional[Path], 
         partial_corpus = corpus[:partial_corpus_line_number * 1000]
 
         if partial_corpus_filepath is None:
-            data_path = Path(".") / "data"
-            data_path.mkdir(exist_ok=True)
-            partial_corpus_filepath = data_path / f"{corpus_filepath.stem}_{len(partial_corpus)}.txt"
+            partial_corpus_filepath = getDataFolder() / f"{corpus_filepath.stem}_{len(partial_corpus)}.txt"
 
         with open(partial_corpus_filepath, "w+") as partial_corpus_f:
             partial_corpus_f.writelines(partial_corpus)
@@ -261,20 +260,17 @@ def sage_per_chunk(tid, model: SaGeTokenizer, data, embeddings, chunk_size: int=
 
 def init_logger(experiment_name: str):
     timestamp_str = time.strftime("%Y%m%d_%H%M%S")
-    logs_path = Path(".") / "logs"
-    logs_path.mkdir(exist_ok=True)
-    log_filename = logs_path / f"{experiment_name}_{timestamp_str}.log"
+    log_filename = getLogsFolder() / f"{experiment_name}_{timestamp_str}.log"
     logging.basicConfig(filename=log_filename.as_posix(),
                         format="%(asctime)s - %(message)s",
                         datefmt="%m/%d/%Y %H:%M:%S",
                         level=logging.INFO)
 
-    print(f"Logs will be stored in {log_filename}")
+    print(f"Logs will be stored in {log_filename.as_posix()}")
 
 
 def get_output_folder(experiment_name: str) -> Tuple[Path, Path, Path]:
-    results_path = Path(".") / "results" / experiment_name
-    results_path.mkdir(exist_ok=True, parents=True)
+    results_path = getResultsFolder() / experiment_name
 
     vocab_folder = results_path / "sage_vocabs"
     vocab_folder.mkdir(exist_ok=True)
@@ -290,8 +286,7 @@ def get_output_folder(experiment_name: str) -> Tuple[Path, Path, Path]:
 
 def set_random_seed(experiment_name: str, random_seed: int):
     # Log seed
-    results_path = Path(".") / "results"
-    seed_filepath = results_path / experiment_name / "seed.txt"
+    seed_filepath = getResultsFolder() / experiment_name / "seed.txt"
     with open(seed_filepath, "w+") as f:
         f.write(str(random_seed))
 

--- a/src/sage_tokenizer/utils.py
+++ b/src/sage_tokenizer/utils.py
@@ -294,7 +294,7 @@ def sage_per_chunk(tid: int, model: SaGeTokenizer, data: Iterable[str], embeddin
     n_examples_seen = 0
     for i, sentence in enumerate(data):
         n_examples_seen += 1
-        total_tokens += model.fast_sage(bytes(sentence, 'utf-8'), triples, ablated_sizes)
+        total_tokens += model.fast_sage(model.pretokenize(sentence), triples, ablated_sizes)
 
         # if filled up chunk, then compute the losses
         # to free up memory

--- a/src/sage_tokenizer/utils.py
+++ b/src/sage_tokenizer/utils.py
@@ -103,7 +103,7 @@ def load_corpus(corpus_filepath: Path, partial_corpus_filepath: Optional[Path], 
     return partial_corpus
 
 
-def divide_data_by_num(data, num_procs):
+def divide_data_by_num(data: List[str], num_procs: int) -> Iterable[List[str]]:
     """
     Split the data given the number of chunks we expect
     Returns a generator
@@ -138,7 +138,7 @@ def compute_losses(losses, all_triples, embeddings):
         losses[ablated_token_id] = losses.get(ablated_token_id, 0.0) + triples_loss[idx]
 
 
-def run_sage_parallel(embeddings, partial_corpus, sage_model: SaGeTokenizer, workers_number: int):
+def run_sage_parallel(embeddings: np.ndarray, partial_corpus: List[str], sage_model: SaGeTokenizer, workers_number: int):
     logging.info(f"Splitting data into {workers_number} chunks.")
     data_chunk_gen = divide_data_by_num(partial_corpus, workers_number)
 

--- a/src/sage_tokenizer/utils.py
+++ b/src/sage_tokenizer/utils.py
@@ -1,5 +1,5 @@
 # Copyright © 2023 Kensho Technologies, LLC
-from typing import Iterable, Tuple, List, Optional
+from typing import Iterable, Tuple, List, Optional, Dict
 
 import json
 import logging
@@ -18,13 +18,12 @@ from .model import SaGeTokenizer
 from .paths import getDataFolder, getLogsFolder, getResultsFolder
 
 
-def write_vocab(vocab, filename):
+def write_vocab(vocab: Dict[bytes,int], filename: Path):
     """
-    Dump the vocab to a file, encoded as characters here.
-    No special tokens are added; they are saved in same order by index, so should preserve order.
+    Dump the byte vocab to a file, encoded as hex characters inside this function.
+    Saved in same order by index, so should preserve order.
+    No special tokens are added.
     """
-    vocab_size = len(vocab)
-
     # write these in increasing index order
     # so same as any previous order
     byindex = sorted([(idx, token) for token, idx in vocab.items()])
@@ -59,7 +58,6 @@ def load_vocab(vocab_filepath: Path) -> List[bytes]:
     Input file has one vocab word per line, each hex encoded.
     """
     vocab_filepath = Path(vocab_filepath)
-
     if not vocab_filepath.exists():
         raise FileNotFoundError(f'Missing vocab file: {vocab_filepath.as_posix()}')
 
@@ -141,7 +139,7 @@ def compute_losses(losses, all_triples, embeddings):
 
 
 def run_sage_parallel(embeddings, partial_corpus, sage_model: SaGeTokenizer, workers_number: int):
-    logging.info(f"Splitting Data into {workers_number} chunks.")
+    logging.info(f"Splitting data into {workers_number} chunks.")
     data_chunk_gen = divide_data_by_num(partial_corpus, workers_number)
 
     # these get aggregated over each chunk


### PR DESCRIPTION
For my own understanding of the code and for better IDE support, I tried annotating all function parameters and return values with their static type. I also moved documentation from comments above the functions to docstrings inside the functions.

Paths were originally given as strings, but `Path` objects are much more convenient and common use. *All interfaces are backwards-compatible,* meaning you can still give strings where you are now expected to give a `Path` and those strings will be converted to a `Path` automatically.

There is now a function accessible to the user with `from sage_tokenizer import setSageFolder` which allows them to specify a folder *under which* the `results/` and `stats/` etc... are created. It defaults to the current working directory which is what happened originally.